### PR TITLE
convenient startup script

### DIFF
--- a/rMwhiteboard.command
+++ b/rMwhiteboard.command
@@ -31,7 +31,11 @@ if [ $? -eq 0 ]
 then
   echo "** reMarkable was found"
   echo "** connecting whiteboard to $rMhostname"
-  
+
+  # open browser window after server had time to start up
+  (sleep 2 && open http://localhost:8001) &
+
+  # start server
   cd $runCommandPath
   $runCommandPath/run.sh --ssh-hostname $rMhostname
 

--- a/rMwhiteboard.command
+++ b/rMwhiteboard.command
@@ -1,0 +1,42 @@
+#!/bin/zsh
+#
+# Start rM whiteboard application 'pipes-and-paper-enhanced'
+# 
+# Will look for rM device on two different hostnames
+# (e.g. Wifi and USB)
+# 
+
+## (assignments must not have spaces around = sign...)
+rMhostname="rm2"
+rMhostname2="rm2usb"
+
+## Do not enclose a path with ~ in "", otherwise the ~ is not expanded 
+runCommandPath=~/Develop/pipes-and-paper-enhanced
+
+# is the rM online?
+# (will timeout with exit code 2 if not)
+echo "** searching for reMarkable..."
+# e.g. wifi
+ping -c 1 -t 5 $rMhostname
+# not found
+if (( ? != 0 )) then
+  # try e.g. usb
+  rMhostname=$rMhostname2
+  echo "trying $rMhostname..."
+  ping -c 1 -t 5 $rMhostname
+fi
+
+# evaluate exit code
+if [ $? -eq 0 ]
+then
+  echo "** reMarkable was found"
+  echo "** connecting whiteboard to $rMhostname"
+  
+  cd $runCommandPath
+  $runCommandPath/run.sh --ssh-hostname $rMhostname
+
+  exit $?
+else
+  echo "** reMarkable NOT FOUND in the local network" >&2
+  exit 1
+fi


### PR DESCRIPTION
As per https://github.com/Pyrrhu5/pipes-and-paper-enhanced/issues/2#issue-1515106905 I added a zsh script to check the network for two different hostnames, take the first found and start p&p with it.
The .command extensions allows it to be double clicked like an app on a Mac.
Could be started on the CLI, too; could then be renamed .sh, but that's not required.
Please use or modify as you like :)